### PR TITLE
Add Slack Workspace link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This project lists Ugandans who might get arrested, detained, kidnapped, or go m
 
 ![Kidnappings & Missing Persons Uganda](screenshot.png)
 
+Join the Slack Workspace to collaborate with other developers.
+
+[![slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://join.slack.com/t/marchtoparliamentug/shared_invite/zt-2n63veudi-TjcscMIMsO31AqN7rGV7ZQ)
+
+
 ## How to Contribute?
 
 To contribute, you can edit `data.json` with correct details of the person that's been reported or presumed missing, arrested, or detained, and then send a Pull Request (PR).


### PR DESCRIPTION
A link to join the Slack Workspace has been added to the README.md file. This will allow other developers who want to collaborate to easily find the workspace and join the discussions.

<img width="601" alt="Screenshot 2024-07-23 at 4 53 43 PM" src="https://github.com/user-attachments/assets/532dc1c0-5bf6-4708-9fa4-a5bc9999bca8">
