### PR TITLE
Refactor index and analytics page

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -57,7 +57,8 @@
     }
         </script>
     <!-- Schema Markup data ends -->
-    <!-- Boostrap css -->
+
+    <!-- bootstrap  -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <!-- Link to external CSS -->
@@ -69,9 +70,9 @@
         <h1>Analytics | Kidnappings & Missing Persons in Uganda</h1>
     </div>
 
-    <div class="container">
+    <div class="container-fluid">
         <div class="row mt-5">
-            <div class="col">
+            <div class="col col-md-6">
                 <div class="card">
                     <div class="card-header">
                         <h3 class="text-white">Missing people by holding location</h3>
@@ -80,63 +81,56 @@
                         <canvas id="holdingLocationChart"></canvas>
                     </div>
                 </div>
-                <div class="col">
-                    <div class="card">
-                        <div class="card-header">
-                            <h3 class="text-white">Missing people by gender</h3>
-                        </div>
-                        <div class="card-body">
-                            <canvas id="genderChart"></canvas>
-                        </div>
-                    </div>
-                </div>
+            </div>
 
-                <div class="col">
-                    <div class="card">
-                        <div class="card-header">
-                            <h3 class="text-white">Missing people by status</h3>
-                        </div>
-                        <div class="card-body">
-                            <canvas id="statusChart"></canvas>
-                        </div>
+            <div class="col col-md-6">
+                <div class=" card">
+                    <div class="card-header">
+                        <h3 class="text-white">Missing people by gender</h3>
                     </div>
-                </div>
-
-                <div class="col">
-                    <div class="card">
-                        <div class="card-header">
-                            <h3 class="text-white">Missing people by last known location</h3>
-                        </div>
-                        <div class="card-body">
-                            <canvas id="lastKnownLocationChart"></canvas>
-                        </div>
+                    <div class="card-body">
+                        <canvas id="genderChart"></canvas>
                     </div>
                 </div>
             </div>
         </div>
 
+        <div class="row mt-5">
 
-
-        <footer class="footer">
-            <div class="footer-content">
-                <nav class="footer-nav">
-                    <a href="./privacy.html" title="Privacy Policy" rel="noopener" target="_blank">Privacy Policy</a>
-                    <a href="./cookies.html" title="Cookie Policy" rel="noopener" target="_blank">Cookie Policy</a>
-                    <a href="./analytics.html" title="Analytics " rel="noopener" target="_blank"> Analytics</a><br>
-                </nav>
-                <p class="copyright">
-                    <span id="current-year"></span> &copy; Kidnappings & Missing Persons in Uganda. All rights reserved.
-                </p>
-                <p class="current-time" id="current-time"></p>
+            <div class="col col-md-6">
+                <div class=" card">
+                    <div class="card-header">
+                        <h3 class="text-white">Missing people by status</h3>
+                    </div>
+                    <div class="card-body">
+                        <canvas id="statusChart"></canvas>
+                    </div>
+                </div>
             </div>
-        </footer>
 
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-            integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
-            crossorigin="anonymous"></script>
-        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-        <script type="text/javascript" src="./src/js/analytics.js"></script>
-        <script src="./src/js/time.js"></script>
+            <div class="col col-md-6">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="text-white">Missing people by last known location</h3>
+                    </div>
+                    <div class="card-body">
+                        <canvas id="lastKnownLocationChart"></canvas>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    
+    <div w3-include-html="src/partials/footer.html"></div>
+    <script type="text/javascript" src="src/js/scripts.js"></script>
+    <script src="./src/js/include.js"></script>
+    <script src="./src/js/time.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script type="text/javascript" src="./src/js/analytics.js"></script>
 </body>
 
 </html>

--- a/cookies.html
+++ b/cookies.html
@@ -1,17 +1,65 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cookies Policy</title>
-    <!-- Link to external CSS -->
-    <link rel="stylesheet" href="src/css/styles.css">
-    <style>
-        body {
-            padding: 20px
+    <head>
+        <!-- Cookie Banner -->
+        <!-- Start cookieyes banner -->
+        <script id="cookieyes" type="text/javascript"
+            src="https://cdn-cookieyes.com/client_data/5ae40288320e48428eecee4b/script.js"></script>
+        <!-- End cookieyes banner -->
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Kidnappings & Missing Persons in Uganda</title>
+        <!-- Meta tags SEO -->
+        <meta name="description"
+            content="Find missing loved ones in Uganda. Report disappearances. View photos, descriptions. Get support resources. Help bring people home." />
+        <meta name="keywords" content="missing persons Uganda, kidnapped Ugandans, abducted Ugandans" />
+        <meta name="author" content="Wes Kambale" />
+        <!-- Social Media Meta Tags -->
+        <meta property="og:title" content="Missing persons Uganda" />
+        <meta property="og:description"
+            content="Find missing loved ones in Uganda. Report disappearances. View photos, descriptions. Get support resources. Help bring people home." />
+        <meta property="og:image" content="./src/img/image_of_person.jpg" />
+        <meta property="og:url" content="https://missingpersonsug.org" />
+        <meta name="twitter:title" content="Missing Persons Uganda" />
+        <meta name="twitter:description"
+            content="Find missing loved ones in Uganda. Report disappearances. View photos, descriptions. Get support resources. Help bring people home." />
+        <meta name="twitter:image" content="./src/img/image_of_person.jpg" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <!-- Social Media Meta Tags End-->
+    
+        <!--
+            site.manifest provides metadata used when your web app is installed on a
+            user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+        -->
+        <link rel="manifest" href="./site.webmanifest" />
+        <!-- Manifest Ends -->
+    
+        <!-- Favicon -->
+        <link rel="shortcut icon" href="./src/assets/favicon.ico" type="image/x-icon" />
+        <link href="./src/assets/apple-touch-icon.png" rel="apple-touch-icon" />
+    
+        <!-- Schema Markup data -->
+        <script type="application/ld+json">
+        {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "Missing Persons Uganda",
+        "url": "https://missingpersonsug.com",
+        "logo": "https://missingpersonsug.com/logo.webp",
+        "sameAs": [
+            "",
+            "",
+            "",
+            "",
+            ""
+            ]
         }
-    </style>
-</head>
+            </script>
+        <!-- Schema Markup data ends -->
+    
+        <!-- Link to external CSS -->
+        <link rel="stylesheet" href="src/css/styles.css">
+    </head>
 <body>
     <h1>COOKIE POLICY</h1>
     
@@ -125,20 +173,8 @@
     If you have any questions about our use of cookies or other technologies, please contact us at:
     
     Missing Persons Uganda
-
+    <div w3-include-html="src/partials/footer.html"></div>
+    <script src="./src/js/include.js"></script>
+    <script src="./src/js/time.js"></script>
 </body>
-<footer class="footer">
-    <div class="footer-content">
-        <nav class="footer-nav">
-            <a href="./privacy.html" title="Privacy Policy" rel="noopener" target="_blank">Privacy Policy</a>
-            <a href="./cookies.html" title="Cookie Policy" rel="noopener" target="_blank">Cookie Policy</a>
-            <a href="./analytics.html" title="Analytics " rel="noopener" target="_blank"> Analytics</a><br>
-        </nav>
-        <p class="copyright">
-            <span id="current-year"></span> &copy; Kidnappings & Missing Persons in Uganda. All rights reserved.
-        </p>
-        <p class="current-time" id="current-time"></p>
-    </div>
-</footer>
-<script src="./src/js/time.js"></script>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,47 +1,46 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <!-- Cookie Banner -->
-        <!-- Start cookieyes banner -->
-        <script id="cookieyes" type="text/javascript"
-            src="https://cdn-cookieyes.com/client_data/5ae40288320e48428eecee4b/script.js"></script>
-        <!-- End cookieyes banner -->
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Kidnappings & Missing Persons in Uganda</title>
-        <!-- Meta tags SEO -->
-        <meta name="description"
-            content="Find missing loved ones in Uganda. Report disappearances. View photos, descriptions. Get support resources. Help bring people home." />
-        <meta name="keywords"
-            content="missing persons Uganda, kidnapped Ugandans, abducted Ugandans" />
-        <meta name="author" content="Wes Kambale" />
-        <!-- Social Media Meta Tags -->
-        <meta property="og:title" content="Missing persons Uganda" />
-        <meta property="og:description"
-            content="Find missing loved ones in Uganda. Report disappearances. View photos, descriptions. Get support resources. Help bring people home." />
-        <meta property="og:image" content="./src/img/image_of_person.jpg" />
-        <meta property="og:url" content="https://missingpersonsug.org" />
-        <meta name="twitter:title" content="Missing Persons Uganda" />
-        <meta name="twitter:description"
-            content="Find missing loved ones in Uganda. Report disappearances. View photos, descriptions. Get support resources. Help bring people home." />
-        <meta name="twitter:image" content="./src/img/image_of_person.jpg" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <!-- Social Media Meta Tags End-->
 
-        <!--
+<head>
+    <!-- Cookie Banner -->
+    <!-- Start cookieyes banner -->
+    <script id="cookieyes" type="text/javascript"
+        src="https://cdn-cookieyes.com/client_data/5ae40288320e48428eecee4b/script.js"></script>
+    <!-- End cookieyes banner -->
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kidnappings & Missing Persons in Uganda</title>
+    <!-- Meta tags SEO -->
+    <meta name="description"
+        content="Find missing loved ones in Uganda. Report disappearances. View photos, descriptions. Get support resources. Help bring people home." />
+    <meta name="keywords" content="missing persons Uganda, kidnapped Ugandans, abducted Ugandans" />
+    <meta name="author" content="Wes Kambale" />
+    <!-- Social Media Meta Tags -->
+    <meta property="og:title" content="Missing persons Uganda" />
+    <meta property="og:description"
+        content="Find missing loved ones in Uganda. Report disappearances. View photos, descriptions. Get support resources. Help bring people home." />
+    <meta property="og:image" content="./src/img/image_of_person.jpg" />
+    <meta property="og:url" content="https://missingpersonsug.org" />
+    <meta name="twitter:title" content="Missing Persons Uganda" />
+    <meta name="twitter:description"
+        content="Find missing loved ones in Uganda. Report disappearances. View photos, descriptions. Get support resources. Help bring people home." />
+    <meta name="twitter:image" content="./src/img/image_of_person.jpg" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <!-- Social Media Meta Tags End-->
+
+    <!--
         site.manifest provides metadata used when your web app is installed on a
         user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-        <link rel="manifest" href="./site.webmanifest" />
-        <!-- Manifest Ends -->
+    <link rel="manifest" href="./site.webmanifest" />
+    <!-- Manifest Ends -->
 
-        <!-- Favicon -->
-        <link rel="shortcut icon" href="./src/assets/favicon.ico"
-            type="image/x-icon" />
-        <link href="./src/assets/apple-touch-icon.png" rel="apple-touch-icon" />
+    <!-- Favicon -->
+    <link rel="shortcut icon" href="./src/assets/favicon.ico" type="image/x-icon" />
+    <link href="./src/assets/apple-touch-icon.png" rel="apple-touch-icon" />
 
-        <!-- Schema Markup data -->
-        <script type="application/ld+json">
+    <!-- Schema Markup data -->
+    <script type="application/ld+json">
     {
     "@context": "https://schema.org",
     "@type": "Organization",
@@ -57,62 +56,37 @@
         ]
     }
         </script>
-        <!-- Schema Markup data ends -->
+    <!-- Schema Markup data ends -->
 
-        <!-- Link to external CSS -->
-        <link rel="stylesheet" href="src/css/styles.css">
-    </head>
-    <body>
-        <div class="header">
-            <h1>Kidnappings & Missing Persons in Uganda</h1>
-        </div>
+    <!-- Link to external CSS -->
+    <link rel="stylesheet" href="src/css/styles.css">
+</head>
 
-        <div class="content">
-            <span class="content__sort-by">Filter by:</span>
-            <div class="search-sort">
-                <div class="content__buttons buttons">
-                    <button data-category="All" class="active">All</button>
-                    <button data-category="Missing">Missing</button>
-                    <button data-category="Arrested">Arrested</button>
-                    <button data-category="Fallen">Fallen</button>
-                    <button data-category="Kidnapped">Kidnapped</button>
-                    <button data-category="Released">Released</button>
-                </div>
-                <input type="text" id="searchInput"
-                    placeholder="Search Person's Name...">
+<body>
+    <div class="header">
+        <h1>Kidnappings & Missing Persons in Uganda</h1>
+    </div>
+
+    <div class="content">
+        <span class="content__sort-by">Filter by:</span>
+        <div class="search-sort">
+            <div class="content__buttons buttons">
+                <button data-category="All" class="active">All</button>
+                <button data-category="Missing">Missing</button>
+                <button data-category="Arrested">Arrested</button>
+                <button data-category="Fallen">Fallen</button>
+                <button data-category="Kidnapped">Kidnapped</button>
+                <button data-category="Released">Released</button>
             </div>
-            <div id="persons" class="persons"></div>
+            <input type="text" id="searchInput" placeholder="Search Person's Name...">
         </div>
+        <div id="persons" class="persons"></div>
+    </div>
 
-        <script type="text/javascript" src="src/js/scripts.js"></script>
-    </body>
-    <footer class="footer">
-        <div class="footer-content">
-            <nav class="footer-nav">
-                <a href="./privacy.html" title="Privacy Policy" rel="noopener" target="_blank">Privacy Policy</a>
-                <a href="./cookies.html" title="Cookie Policy" rel="noopener" target="_blank">Cookie Policy</a>
-                <a href="./analytics.html" title="Analytics " rel="noopener" target="_blank"> Analytics</a><br>
-            </nav>
-            <p class="copyright">
-                <span id="current-year"></span> &copy; Kidnappings & Missing Persons in Uganda. All rights reserved.
-            </p>
-            <p class="current-time" id="current-time"></p>
-        </div>
-    </footer>
+    <script type="text/javascript" src="src/js/scripts.js"></script>
+    <div w3-include-html="src/partials/footer.html"></div>
+    <script src="./src/js/include.js"></script>
+    <script src="./src/js/time.js"></script>
+</body>
 
-
-    <script>
-        function updateDateTime() {
-            const now = new Date();
-            const year = now.getFullYear();
-            const time = now.toLocaleTimeString();
-            const date = now.toLocaleDateString();
-
-            document.getElementById('current-year').textContent = year;
-            document.getElementById('current-time').textContent = `${date} ${time}`;
-        }
-
-        updateDateTime();
-        setInterval(updateDateTime, 1000);
-    </script>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -8693,20 +8693,8 @@
 
 </head>
 <body>
-    
+    <div w3-include-html="src/partials/footer.html"></div>
+    <script src="./src/js/include.js"></script>
+    <script src="./src/js/time.js"></script>
 </body>
-<footer class="footer">
-    <div class="footer-content">
-        <nav class="footer-nav">
-            <a href="./privacy.html" title="Privacy Policy" rel="noopener" target="_blank">Privacy Policy</a>
-            <a href="./cookies.html" title="Cookie Policy" rel="noopener" target="_blank">Cookie Policy</a>
-            <a href="./analytics.html" title="Analytics " rel="noopener" target="_blank"> Analytics</a><br>
-        </nav>
-        <p class="copyright">
-            <span id="current-year"></span> &copy; Kidnappings & Missing Persons in Uganda. All rights reserved.
-        </p>
-        <p class="current-time" id="current-time"></p>
-    </div>
-</footer>
-<script src="./src/js/time.js"></script>
 </html>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -321,3 +321,7 @@ button:hover {
         padding: 0.6rem 1rem;
     }
 }
+
+canvas {
+    max-height: 400px;
+}

--- a/src/js/include.js
+++ b/src/js/include.js
@@ -1,0 +1,35 @@
+function includeHTML(callback) {
+    var z, i, elmnt, file, xhttp;
+    /* Loop through a collection of all HTML elements: */
+    z = document.getElementsByTagName("*");
+    for (i = 0; i < z.length; i++) {
+        elmnt = z[i];
+        /*search for elements with a certain atrribute:*/
+        file = elmnt.getAttribute("w3-include-html");
+        if (file) {
+            /* Make an HTTP request using the attribute value as the file name: */
+            xhttp = new XMLHttpRequest();
+            xhttp.onreadystatechange = function () {
+                if (this.readyState == 4) {
+                    if (this.status == 200) { elmnt.innerHTML = this.responseText; }
+                    if (this.status == 404) { elmnt.innerHTML = "Page not found."; }
+                    /* Remove the attribute, and call this function once more: */
+                    elmnt.removeAttribute("w3-include-html");
+                    includeHTML(callback);
+                }
+            }
+            xhttp.open("GET", file, true);
+            xhttp.send();
+            /* Exit the function: */
+            return;
+        }
+    }
+    /* Call the callback function after all includes are processed */
+    if (callback) callback();
+}
+
+/* Call includeHTML and pass the updateDateTime setup as a callback */
+includeHTML(function() {
+    updateDateTime();
+    setInterval(updateDateTime, 1000);
+});

--- a/src/js/time.js
+++ b/src/js/time.js
@@ -7,6 +7,3 @@ function updateDateTime() {
     document.getElementById('current-year').textContent = year;
     document.getElementById('current-time').textContent = `${date} ${time}`;
 }
-
-updateDateTime();
-setInterval(updateDateTime, 1000)

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -1,0 +1,14 @@
+<footer class="footer">
+    <div class="footer-content">
+        <nav class="footer-nav">
+            <a href="./index.html" title="Home" rel="noopener">Home</a>
+            <a href="./privacy.html" title="Privacy Policy" rel="noopener">Privacy Policy</a>
+            <a href="./cookies.html" title="Cookie Policy" rel="noopener">Cookie Policy</a>
+            <a href="./analytics.html" title="Analytics " rel="noopener"> Analytics</a><br>
+        </nav>
+        <p class="copyright">
+            <span id="current-year"></span> &copy; Kidnappings & Missing Persons in Uganda. All rights reserved.
+        </p>
+        <p class="current-time" id="current-time"></p>
+    </div>
+</footer>


### PR DESCRIPTION
# Refactor index and analytics page.
1. The index page was using a script that was hard coded in the html. I've moved this into a .js file so it can be reused.
1. Other pages were sharing a footer but it was repeated. Following DRY, i've refactored to make sure that all pages use one footer page. Makes it easier if we need to change anything there.
![Screenshot 2024-07-23 at 22 36 15](https://github.com/user-attachments/assets/bc3cc07d-c397-420d-b850-7dc9c473c66f)

1. On the footer, I've also added a `Home` link incase you are looking at any of the other pages and want to go back to home.
1. I've also added the time to all other page by using the footer's partial.
[
![Screenshot 2024-07-23 at 22 36 07](https://github.com/user-attachments/assets/c40c32ed-743f-430a-8f70-37ff41009b2b)
](url)
1. Lastly, i've updated the analytics page to make it easier to look at especially on larger screens by using bootstrap classes. 
![Screenshot 2024-07-23 at 22 35 55](https://github.com/user-attachments/assets/c011ea60-244b-4109-a7d6-a7fa544bf07b)

1. Lastly, cookies, privacy policy and analytics were opening in new tabs. Makes sense to leave everything in one tab. removed all the `target="_blank"`