### PR TITLE
Add spacing and padding on search input for both web and mobile

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -77,6 +77,12 @@ button:hover {
     padding: 1rem 0;
 }
 
+.search-sort input {
+    margin: 1rem 0;
+    font-size: 0.9rem;
+    padding: 0.6rem 1rem;
+}
+
 .filter-and-search {
     flex:2;
     display: flex;


### PR DESCRIPTION
This PR does the following:

- Adds a little spacing around the search input and prevents it being attached to the filter buttons and the cards
- Increases the size (more padding) of the search input, as well as the font size of the input, to match the style in the mobile view